### PR TITLE
Fix https://notabug.org/latvian-list/adblock-latvian/issues/10

### DIFF
--- a/hotfix.txt
+++ b/hotfix.txt
@@ -1179,3 +1179,6 @@
 @@||zlp6s.pw^$script,xmlhttprequest
 ! FDA-2994
 @@||fundingchoicesmessages.google.com^$script,xmlhttprequest,subdocument
+! https://notabug.org/latvian-list/adblock-latvian/issues/10
+delfi.lv#?#section[id^=custom-ads-block]:has([class$=disclaimer])
+@@||atverskapi.delfi.lv^$ghide


### PR DESCRIPTION
With Latvian List still AFK, I figured it's time for desperate makeshift measures.

`delfi.lv#?#section[id^=custom-ads-block]:has([class$=disclaimer])` removes the Swedbank widget with hopeful futureproofing.

I was no longer able to see the Bite and BluOr widgets on that site.

`##.AS-widget` can not be used because it leads to `atverskapi.`**`delfi.lv`**. On the other hand, it did turn out that [that destination site](https://atverskapi.delfi.lv/lv/sludinajumi/3546544-hudora-stoil-130-evro) is using generichide-fixable AAB, for which I propose `@@||atverskapi.delfi.lv^$generichide`