### PR TITLE
tv.vg.no

### DIFF
--- a/hotfix.txt
+++ b/hotfix.txt
@@ -1220,3 +1220,5 @@
 @@||wellgroomedapparel.com^$script,xmlhttprequest
 ! FDA-2994
 @@||fundingchoicesmessages.google.com^$script,xmlhttprequest,subdocument
+! https://gitlab.com/eyeo/adblockplus/abc/adblockpluscore/-/issues/224#note_1111575321
+tv.vg.no#$#abort-on-property-write __AB__


### PR DESCRIPTION
If this doesn't count as a critical issue, *then I don't know what would be.* This needs to be accepted into at least one of the three "ABP Filters" repos *at any and all costs*, due to the very, very high regional popularity of the site in question.

Context: https://gitlab.com/eyeo/adblockplus/abc/adblockpluscore/-/issues/224#note_1111575321

Example page: `https://tv.vg.no/video/243907/verdensrekordforsoek-stor-sjanse-for-at-kroppsdeler-ryker`
ABP version: 3.14.2
Browser: Vivaldi 5.4.2753.51 x64
OS: Windows 11 22H2 x64